### PR TITLE
Add support for gzip content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build:
 	docker build -t edge-validator:latest .
 
 serve:
-	docker run -p 8000:8000 -it edge-validator:latest
+	docker run -e FLASK_ENV -p 8000:8000 -it edge-validator:latest
 
 shell:
 	docker run -p 8000:8000 -it edge-validator:latest pipenv shell

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [bug 1452166](https://bugzilla.mozilla.org/show_bug.cgi?id=1452166) for moti
 Start the docker container to start the local service at `localhost:8000`.
 The following command will fetch the latest image from dockerhub.
 ```bash
-docker run -it mozilla/edge-validator:latest
+docker run -p 8000 -it mozilla/edge-validator:latest
 ```
 
 Simply POST to the endpoint to check if a document is valid.
@@ -43,7 +43,7 @@ It is possible to mount a set of local json-schemas by mounting a folder structu
 
 ```bash
 $ cd mozilla-pipeline-schemas
-$ docker run -v "$(pwd)"/schemas:/app/resources/schemas -it edge-validator
+$ docker run -p 8000 -v "$(pwd)"/schemas:/app/resources/schemas -it edge-validator
 ```
 
 ## User Guide
@@ -136,7 +136,7 @@ The docker environment is suitable for running a local service or for running an
 $ make shell
 
 # Alternatively
-$ docker run -it edge-validator:latest pipenv shell
+$ docker run -p 8000 -it edge-validator:latest pipenv shell
 ```
 
 If you don't require permanent changes to the engine itself, you may pull down a prebuilt docker image through
@@ -174,7 +174,7 @@ You may also run the tests in docker in the same way as CI.
 A `junit.xml` file is generated in a `test-reports` folder.
 
 ```bash
-IMAGE=edge-validator:latest ./test_docker.sh
+IMAGE=edge-validator:latest ./test_env.sh test
 ```
 
 # Running Integration Tests

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+import zlib
 
 import rapidjson
 from flask import Flask, request
@@ -96,9 +97,15 @@ def submit(namespace, doctype, docversion=None, **kwargs):
     resp = ('OK', 200)
 
     try:
+        data = request.get_data()
+        try:
+            data = zlib.decompress(data, 16+zlib.MAX_WBITS)
+        except zlib.error:
+            pass
+
         docversion = docversion or SCHEMA_VERSIONS[namespace][doctype]
         key = "{}.{}".format(doctype, docversion)
-        NAMESPACE_SCHEMAS[namespace][key](request.get_data())
+        NAMESPACE_SCHEMAS[namespace][key](data)
     except ValueError as e:
         resp = ("Validation Error: {}".format(e), 400)
     except KeyError as e:

--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ def load_namespace(base, namespace):
             with open(os.path.join(root, name), "r") as f:
                 key = name.split(".schema.json")[0]
                 schemas[key] = rapidjson.Validator(f.read())
-                print("Registered {}.{} ".format(namespace, key))
+                app.logger.info("Registered {}.{} ".format(namespace, key))
     return schemas
 
 
@@ -103,5 +103,7 @@ def submit(namespace, doctype, docversion=None, **kwargs):
         resp = ("Validation Error: {}".format(e), 400)
     except KeyError as e:
         resp = ("Missing Schema: {}".format(e), 400)
+
+    app.logger.info(resp[0])
     return resp
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import gzip
 from uuid import uuid4
 
 import pytest
@@ -49,9 +50,7 @@ def test_ping_omit_optional(client, ping, route):
     assert rv.status_code == 200
 
 
-def test_ping_wrong_type(client, ping, route):
-    ping["payload"]["baz"]
-    rv = client.post(route,
-                     data=json.dumps(ping),
-                     content_type='application/json')
+def test_ping_gzip_data(client, ping, route):
+    data = gzip.compress(json.dumps(ping).encode())
+    rv = client.post(route, data=data)
     assert rv.status_code == 200

--- a/tests/test_telemetry_ingestion.py
+++ b/tests/test_telemetry_ingestion.py
@@ -30,6 +30,14 @@ def test_telemetry_ingestion_ok(client, ping, default_values):
     assert rv.status_code == 200
 
 
+def test_telemetry_ingestion_append_version(client, ping, default_values):
+    spec = TelemetryURISpec(**default_values)
+    rv = client.post(build_route(spec) + "?v=4",
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 200
+
+
 def test_generic_ingestion_omit_routes(client, ping, default_values):
     for key in default_values.keys():
         # create a new dictionary with the single key nulled out


### PR DESCRIPTION
This fixes issue #30, which means that the docker image can be used to validate data directly from Firefox/telemetry module. See the issue for more detail. 

![image](https://user-images.githubusercontent.com/3304040/44612259-c0ca3380-a7bb-11e8-885f-0259e7b74a2a.png)

The main documents are unfortunately failing tests because of issue #20, where the python rapidjson module does not have std::regex enabled at compile time. 