### PR TITLE
Use fixed suffix for parsing remote folder structure 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ click = "*"
 pytest = "*"
 requests = "*"
 awscli = "*"
+docker = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -146,18 +146,18 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:62100665052a6674830c900b0e008e5e7420a060b7604adb8e3272bd92354cd3",
-                "sha256:8d96ec0de325ea8271cc6aa95b7392bbf548ec4aabd3ffbcdc0619b64edd4a45"
+                "sha256:3eae631655c49c2e71355b43a4e69e10abdb709186f74d19112a0842c4155299",
+                "sha256:bbc4895d8c67bd2f0a5f854953b280b2eb39014431ca640cb8b2594c10f3c2ec"
             ],
             "index": "pypi",
-            "version": "==1.16.75"
+            "version": "==1.16.76"
         },
         "botocore": {
             "hashes": [
-                "sha256:a9e6b55fcb30a01ad5309912286f80c516aed6123b9ac5c8bfb0aeccd943650b",
-                "sha256:e969a68fc2bed981f3b6539cbb191f82b7034f95f04c664b06764446f22b9cee"
+                "sha256:25c39ecc71356287cf79d66981ec77deca374e28043b19b2f818d48aa34272a1",
+                "sha256:419e1a6a1829c49c7aad30efc1e4a9435ad36573ca6a14d94940e7f302aa234a"
             ],
-            "version": "==1.12.65"
+            "version": "==1.12.66"
         },
         "certifi": {
             "hashes": [
@@ -259,11 +259,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:1d131cc532be0023ef8ae265e2a779938d0619bb6c2510f52987ffcba7fa1ee4",
-                "sha256:ca4761407f1acc85ffd1609f464ca20bb71a767803505bd4127d0e45c5a50e23"
+                "sha256:f689bf2fc18c4585403348dd56f47d87780bf217c53ed9ae7a3e2d7faa45f8e9",
+                "sha256:f812ea39a0153566be53d88f8de94839db1e8a05352ed8a49525d7d7f37861e9"
             ],
             "index": "pypi",
-            "version": "==4.0.1"
+            "version": "==4.0.2"
         },
         "python-dateutil": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -25,11 +25,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
-                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "index": "pypi",
-            "version": "==6.7"
+            "version": "==7.0"
         },
         "dockerflow": {
             "hashes": [
@@ -49,9 +49,10 @@
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519"
+                "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
+                "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
             ],
-            "version": "==0.24"
+            "version": "==1.1.0"
         },
         "jinja2": {
             "hashes": [
@@ -62,31 +63,63 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
+                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
+                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
+                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
+                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
+                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
+                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
+                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
+                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
+                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
+                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
+                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
+                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
+                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
+                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
+                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
+                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
+                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
+                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
+                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
+                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
+                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
+                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
+                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
+                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
+                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
+                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
+                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
             ],
-            "version": "==1.0"
+            "version": "==1.1.0"
         },
         "python-rapidjson": {
             "hashes": [
-                "sha256:00c9eac2cb64d6b82d2b0eb725c2fe5edc2ca9cafa329ffbe4696450bdd0dd2c",
-                "sha256:351c08d2c3e529291ac2bb5f8fec8ab0588b6010db51874fa4ea8d751a16054f",
-                "sha256:38d4bc736341ece4ecab45c79161111f0176c6a21f4ed7325f6be5269f53168e",
-                "sha256:3943bc26baca6190766ab0460f6b066cd6f74e2c18208c4cfa086eb030b2f853",
-                "sha256:3d278502b1046c17b33f698bbb0007586777e0aa0e513e7eea08b49bd1e06904",
-                "sha256:56cefa7f8cee4f5c4bf07f6d683f80c827edf0aeed98572e7bd93e047962c499",
-                "sha256:6d474e73c70e98dec1d831cb2d8f56755f9269b7c238e8ddfab9368a76370675",
-                "sha256:7303bb38007c24e3c4e9118b9828e1bb916dc79ee21283fbb4dfe55471bb833b",
-                "sha256:74030be1aea5bacc18fc1f4f91bbedfe644f9abbf41ec2ca01e06cf8a273c9e0",
-                "sha256:7654ad83b727fb1839e5f9b5cc8de3f9fdb86f95912961b16ca71a972016203d",
-                "sha256:969a51dfe82ec1237e29102b9676e55756d7039e3d9236755edbab0459a89bc2",
-                "sha256:a5acd7445f0e711ba9e17a5bda8c47c203f417235b533a59cc57adb4cd351eff",
-                "sha256:be283fe42fb21a6a2d48f9884e79b49da5908df79187ec3697f7fd68330d76ed",
-                "sha256:d60c29bc14cc889af8c2118a526ebd66aff887d34918a76d67dd05cc76f8b488",
-                "sha256:d8880750bcc6fbb29ffdad5e01e793fb80bbf387ff3a2201ddf91a5517aaf2c4",
-                "sha256:e9011bca106ce32753c7d67f8d95ea335fd823ebbb11104eca34cff47741e7d6"
+                "sha256:0156939b77d7a4f2ef5f627cabbfcae52f993325626cefc783fe529d42092f51",
+                "sha256:0a7729c711d9be2b6c0638ce4851d398e181f2329814668aa7fda6421a5da085",
+                "sha256:0cddd7afb5f95d7966836e93a8eae5e31f38e602b57ba6749f9f14473c09470b",
+                "sha256:1b5990989d446e1dbffa87e60b38043a9e5fc28ded970d3776d06e3ae68d1eb6",
+                "sha256:209e9d9b813641a7bc5ead254f4dfe3a2b43f39ca16eabb36e6b796316cc5a49",
+                "sha256:2241e6b0ba4e9bec139e97f6d9f17e9d308de905d66bf5cf88c5636193474a5f",
+                "sha256:2cdd343ec844ec06c6819c79cb83c3ba52b12bb421923ddfdf94f1e233b09d34",
+                "sha256:4066a69fb074262d2309abe0436630241ca5be5e3c23147c178a138c944ffeba",
+                "sha256:626bdea30d3029c3069f5a5b324e8f92f775ae7bb90568022a93f8906954518a",
+                "sha256:7785ebc48f66386fe185a2034050a3db493d2b2ac6f01f4504b38f663e2136f9",
+                "sha256:77caf809475356690152ee5931380e54cafe7202838e220608794987837a1014",
+                "sha256:784a13b6af5380ccd6dcafbf19fef78bd1028f0c4356be810c1edfbe99e08d07",
+                "sha256:7abb51dac9092450e31b874f9f02e141cd42a7ebc6ce2ed3191891c53da976a8",
+                "sha256:9ca153a4a5f9c1c5774ebec085d6775124dbbf0f7bf3894dec2cbc0910963a8f",
+                "sha256:a55a386f87213b1cc69bb4979eb6a77a1f149216f0514adeb06ac0e8fb7e3904",
+                "sha256:b844728f6a932e50ea6650d2207e81506c20a3d318651ed7b86ed101b75f50dd",
+                "sha256:bd20cd2e6a31a5b42da6c204fe453f67468e862d34f5d678d0df4195ac8039c2",
+                "sha256:f1201cadb61ce05a9ec896c4f0e4365d2500894990cf8c885e271acdb4038b95",
+                "sha256:f32fda807dea4805b1b93affbde1af7a06119e5828b81eb71a04fa0580c6e5ad",
+                "sha256:f4a3a20321e7b5bd7a3fe9451cc4437c1c6a221dc31784a1fc4de5613eccaab3",
+                "sha256:f7fff2a22754c4d1b9a34f16d124d92f414f2472d043a652a83b911b3736735e"
             ],
             "index": "pypi",
-            "version": "==0.6.1"
+            "version": "==0.6.3"
         },
         "werkzeug": {
             "hashes": [
@@ -99,39 +132,39 @@
     "develop": {
         "atomicwrites": {
             "hashes": [
-                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
-                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "version": "==1.1.5"
+            "version": "==1.2.1"
         },
         "attrs": {
             "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
-            "version": "==18.1.0"
+            "version": "==18.2.0"
         },
         "awscli": {
             "hashes": [
-                "sha256:12a5f618cd825b3e1b1facf74239a1b072d9b34536129790593248ec74f12d83",
-                "sha256:ad1a8955806433ec83aea2a7938ee921204df3c4b46bdd634e35900f58dc517e"
+                "sha256:3374a15de2270a37637e3f6e79db8f710dcb3d8593dc05ec4961af129fdc4da4",
+                "sha256:3a61dc9bee14c17ef46a49f73b98fa28cd996a6af7acf9672307205ccd607995"
             ],
             "index": "pypi",
-            "version": "==1.15.33"
+            "version": "==1.16.74"
         },
         "botocore": {
             "hashes": [
-                "sha256:aa8c2562e477ce5333c6ac4bcf594a7223ec032a0083fdf547532a04698cc382",
-                "sha256:bf57714190281a5319786eb20b0e0c1620db8c77a4dcad08003bcebb5730932e"
+                "sha256:85291fff27fbf413095be248590bfbaafa32f3fcc45db4d6f2efe2d6f0542978",
+                "sha256:93dc0bea94d0ee785581f297a11311739f51d6ede8c9026a015dc37e6e014694"
             ],
-            "version": "==1.10.33"
+            "version": "==1.12.64"
         },
         "certifi": {
             "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
             ],
-            "version": "==2018.4.16"
+            "version": "==2018.11.29"
         },
         "chardet": {
             "hashes": [
@@ -157,10 +190,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
-            "version": "==2.6"
+            "version": "==2.8"
         },
         "jmespath": {
             "hashes": [
@@ -171,86 +204,83 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
-                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
-                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
             ],
-            "version": "==4.2.0"
+            "version": "==4.3.0"
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
-                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
-                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
+                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
             ],
-            "version": "==0.6.0"
+            "version": "==0.8.0"
         },
         "py": {
             "hashes": [
-                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",
-                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
+                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
+                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
             ],
-            "version": "==1.5.3"
+            "version": "==1.7.0"
         },
         "pyasn1": {
             "hashes": [
-                "sha256:2f57960dc7a2820ea5a1782b872d974b639aa3b448ac6628d1ecc5d0fe3986f2",
-                "sha256:3651774ca1c9726307560792877db747ba5e8a844ea1a41feb7670b319800ab3",
-                "sha256:602fda674355b4701acd7741b2be5ac188056594bf1eecf690816d944e52905e",
-                "sha256:8fb265066eac1d3bb5015c6988981b009ccefd294008ff7973ed5f64335b0f2d",
-                "sha256:9334cb427609d2b1e195bb1e251f99636f817d7e3e1dffa150cb3365188fb992",
-                "sha256:9a15cc13ff6bf5ed29ac936ca941400be050dff19630d6cd1df3fb978ef4c5ad",
-                "sha256:a66dcda18dbf6e4663bde70eb30af3fc4fe1acb2d14c4867a861681887a5f9a2",
-                "sha256:ba77f1e8d7d58abc42bfeddd217b545fdab4c1eeb50fd37c2219810ad56303bf",
-                "sha256:cdc8eb2eaafb56de66786afa6809cd9db2df1b3b595dcb25aa5b9dc61189d40a",
-                "sha256:d01fbba900c80b42af5c3fe1a999acf61e27bf0e452e0f1ef4619065e57622da",
-                "sha256:f281bf11fe204f05859225ec2e9da7a7c140b65deccd8a4eb0bc75d0bd6949e0",
-                "sha256:fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc"
+                "sha256:0ad0fe0593dde1e599cac0bf65bb1a4ec663032f0bc68ee44850db4251e8c501",
+                "sha256:13794d835643ee970b2c059dbfe4eb5d751e16c693c8baee61c526abd209e5c7",
+                "sha256:49a8ed515f26913049113820b462f698e6ed26df62c389dafb6fa3685ddca8de",
+                "sha256:74ac8521a0480f228549be20bea555ae35678f0e754c2fbc6f1576b0959bec43",
+                "sha256:89399ca8ecd4524f974e926d4ef9e7a787903e01f0a9cdff3131ad1361792fe5",
+                "sha256:8f291e0338d519a1a0d07f0b9d03c9265f6be26eb32fdd21af6d3259d14ea49c",
+                "sha256:b9d3abc5031e61927c82d4d96c1cec1e55676c1a991623cfed28faea73cdd7ca",
+                "sha256:d3bbd726c1a760d4ca596a4d450c380b81737612fe0182f5bb3caebc17461fd9",
+                "sha256:dea873d6c907c1cf1341fd88742a61efce33227d7743cb37564ab7d7e77dd9fd",
+                "sha256:ded5eea5cb88bc1ce9aa074b5a3092f95ce4741887e317e9b49c7ece75d7ea0e",
+                "sha256:e8b69ea2200d42201cbedd486eedb8980f320d4534f83ce2fb468e96aa5545d0",
+                "sha256:edad117649643230493aeb4955456ce19ab4b12e94489dde6f7094cdb5a3c87e",
+                "sha256:f58f2a3d12fd754aa123e9fa74fb7345333000a035f3921dbdaa08597aa53137"
             ],
-            "version": "==0.4.3"
+            "version": "==0.4.4"
         },
         "pytest": {
             "hashes": [
-                "sha256:26838b2bc58620e01675485491504c3aa7ee0faf335c37fcd5f8731ca4319591",
-                "sha256:32c49a69566aa7c333188149ad48b58ac11a426d5352ea3d8f6ce843f88199cb"
+                "sha256:1d131cc532be0023ef8ae265e2a779938d0619bb6c2510f52987ffcba7fa1ee4",
+                "sha256:ca4761407f1acc85ffd1609f464ca20bb71a767803505bd4127d0e45c5a50e23"
             ],
             "index": "pypi",
-            "version": "==3.6.1"
+            "version": "==4.0.1"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
-                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
+                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
             ],
             "markers": "python_version >= '2.7'",
-            "version": "==2.7.3"
+            "version": "==2.7.5"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:0c507b7f74b3d2dd4d1322ec8a94794927305ab4cebbe89cc47fe5e81541e6e8",
-                "sha256:16b20e970597e051997d90dc2cddc713a2876c47e3d92d59ee198700c5427736",
-                "sha256:3262c96a1ca437e7e4763e2843746588a965426550f3797a79fca9c6199c431f",
-                "sha256:326420cbb492172dec84b0f65c80942de6cedb5233c413dd824483989c000608",
-                "sha256:4474f8ea030b5127225b8894d626bb66c01cda098d47a2b0d3429b6700af9fd8",
-                "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
-                "sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7",
-                "sha256:5f84523c076ad14ff5e6c037fe1c89a7f73a3e04cf0377cb4d017014976433f3",
-                "sha256:827dc04b8fa7d07c44de11fabbc888e627fa8293b695e0f99cb544fdfa1bf0d1",
-                "sha256:b4c423ab23291d3945ac61346feeb9a0dc4184999ede5e7c43e1ffb975130ae6",
-                "sha256:bc6bced57f826ca7cb5125a10b23fd0f2fff3b7c4701d64c439a300ce665fff8",
-                "sha256:c01b880ec30b5a6e6aa67b09a2fe3fb30473008c85cd6a67359a1b15ed6d83a4",
-                "sha256:ca233c64c6e40eaa6c66ef97058cdc80e8d0157a443655baa1b2966e812807ca",
-                "sha256:e863072cdf4c72eebf179342c94e6989c67185842d9997960b3e69290b2fa269"
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
+                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
-            "version": "==3.12"
+            "version": "==3.13"
         },
         "requests": {
             "hashes": [
-                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
-                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
             ],
             "index": "pypi",
-            "version": "==2.18.4"
+            "version": "==2.21.0"
         },
         "rsa": {
             "hashes": [
@@ -268,17 +298,18 @@
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
-                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
-            "version": "==1.22"
+            "markers": "python_version >= '3.4'",
+            "version": "==1.24.1"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "151029ae4a6f17e460b40b0b82ac7802b20cb556a021e552c23165368bc9ba13"
+            "sha256": "c78f146f4366b9e951955514efab37547319ade466f3c41c8037601a4f30fab8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -146,18 +146,18 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:3374a15de2270a37637e3f6e79db8f710dcb3d8593dc05ec4961af129fdc4da4",
-                "sha256:3a61dc9bee14c17ef46a49f73b98fa28cd996a6af7acf9672307205ccd607995"
+                "sha256:62100665052a6674830c900b0e008e5e7420a060b7604adb8e3272bd92354cd3",
+                "sha256:8d96ec0de325ea8271cc6aa95b7392bbf548ec4aabd3ffbcdc0619b64edd4a45"
             ],
             "index": "pypi",
-            "version": "==1.16.74"
+            "version": "==1.16.75"
         },
         "botocore": {
             "hashes": [
-                "sha256:85291fff27fbf413095be248590bfbaafa32f3fcc45db4d6f2efe2d6f0542978",
-                "sha256:93dc0bea94d0ee785581f297a11311739f51d6ede8c9026a015dc37e6e014694"
+                "sha256:a9e6b55fcb30a01ad5309912286f80c516aed6123b9ac5c8bfb0aeccd943650b",
+                "sha256:e969a68fc2bed981f3b6539cbb191f82b7034f95f04c664b06764446f22b9cee"
             ],
-            "version": "==1.12.64"
+            "version": "==1.12.65"
         },
         "certifi": {
             "hashes": [
@@ -179,6 +179,21 @@
                 "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
             ],
             "version": "==0.3.9"
+        },
+        "docker": {
+            "hashes": [
+                "sha256:145c673f531df772a957bd1ebc49fc5a366bcd55efa0e64bbd029f5cc7a1fd8e",
+                "sha256:666611862edded75f6049893f779bff629fdcd4cd21ccf01d648626e709adb13"
+            ],
+            "index": "pypi",
+            "version": "==3.6.0"
+        },
+        "docker-pycreds": {
+            "hashes": [
+                "sha256:6ce3270bcaf404cc4c3e27e4b6c70d3521deae82fb508767870fdbf772d584d4",
+                "sha256:7266112468627868005106ec19cd0d722702d2b7d5912a28e19b826c3d37af49"
+            ],
+            "version": "==0.4.0"
         },
         "docutils": {
             "hashes": [
@@ -308,8 +323,14 @@
                 "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
                 "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
-            "markers": "python_version >= '3.4'",
             "version": "==1.24.1"
+        },
+        "websocket-client": {
+            "hashes": [
+                "sha256:8c8bf2d4f800c3ed952df206b18c28f7070d9e3dcbd6ca6291127574f57ee786",
+                "sha256:e51562c91ddb8148e791f0155fdb01325d99bb52c4cdbb291aee7a3563fd0849"
+            ],
+            "version": "==0.54.0"
         }
     }
 }

--- a/sync.sh
+++ b/sync.sh
@@ -41,6 +41,18 @@ if [[ ! -d "${schema_path}" ]]; then
     mkdir -p "${schema_path}"
 fi
 
+function path_tail {
+    # $1: path delimited by '/'
+    # $2: number of elements to keep from the tail
+    echo $(echo "$1" | rev | cut -d'/' -f-$2 | rev)
+}
+
+function get_path_value {
+    # $1: path delimited by '/' with elements 'KEY=VALUE'
+    # $2: index of value to parse from path
+    echo $(echo "$1" | cut -d'/' -f$2 | cut -d'=' -f2)
+}
+
 function sync_data {
     src_data_path="s3://${SRC_DATA_BUCKET}/${SRC_DATA_PREFIX}"
 
@@ -53,7 +65,7 @@ function sync_data {
     src_data_path="${src_data_path}/submission_date_s3=${recent_date}/"
 
     # List all available json samples.
-    # ex: amiyaguchi/sanitized-landfill-sample/v2/submission_date_s3=20180529/namespace=telemetry/doc_type=anonymous/doc_version=4/*.json
+    # ex: sanitized-landfill-sample/v3/submission_date_s3=20181212/namespace=telemetry/doc_type=anonymous/doc_version=4/*.json
     paths=$(
         $aws s3 ls --recursive "$src_data_path" |  # recursively list all files
         grep .json |                              # find leaf nodes containing sampled documents
@@ -74,10 +86,12 @@ function sync_data {
             fi
         fi
 
-        submission_date=$(echo "${path}" | cut -d'/' -f4 | cut -d'=' -f2)
-        namespace=$(echo "${path}" | cut -d'/' -f5 | cut -d'=' -f2)
-        doc_type=$(echo "${path}" | cut -d'/' -f6 | cut -d'=' -f2)
-        doc_version=$(echo "${path}" | cut -d'/' -f7 | cut -d'=' -f2)
+        # keep the last 5 components of the directory spec
+        spec=$(path_tail ${path} 5)
+        submission_date=$(get_path_value ${spec} 1)
+        namespace=$(get_path_value ${spec} 2)
+        doc_type=$(get_path_value ${spec} 3)
+        doc_version=$(get_path_value ${spec} 4)
 
         namespace_dir="${data_path}/${submission_date}/${namespace}"
         filename="${doc_type}.${doc_version}.batch.json"

--- a/tests/resources/data/testing/test/test.1.batch.json
+++ b/tests/resources/data/testing/test/test.1.batch.json
@@ -1,0 +1,3 @@
+{"payload": {"foo": true, "bar": 1, "baz": "hello world"}}
+{"payload": {"foo": true, "bar": 2, "baz": "hello world"}}
+{"payload": {"foo": true, "bar": 3, "baz": "hello world"}}

--- a/tests/test_command_sync.py
+++ b/tests/test_command_sync.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import pytest
 import docker
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -27,7 +28,7 @@ def minio():
     container.stop()
 
 
-def awscli(command):
+def awscli(command, cwd=None):
     res = subprocess.run(
         ["aws", "--endpoint-url", "http://localhost:9000"] + command.split(),
         stdout=subprocess.PIPE,
@@ -35,11 +36,22 @@ def awscli(command):
             "AWS_ACCESS_KEY_ID": TEST_ACCESS_KEY,
             "AWS_SECRET_ACCESS_KEY": TEST_SECRET_KEY,
         },
+        cwd=cwd,
     )
-    return res.stdout
+    if not res.returncode == 0:
+        raise RuntimeError(f"aws failed: {str(res)}")
+    return res.stdout.decode("utf-8")
 
 
-def test_containers(minio):
+# directory depths d<k>
+@pytest.mark.parametrize("prefix", [
+    "d1/d2",
+    "d1/d2/d3",
+    "d1/d2/d3/d4"
+])
+def test_synchronize(minio, tmp_path, prefix):
+    cwd = Path(__file__).parent
+
     bucket = "test-bucket"
     submission_date = "20181212"
     namespace = "testing"
@@ -47,6 +59,7 @@ def test_containers(minio):
     doc_version = "1"
 
     awscli(f"s3 mb s3://{bucket}")
+
     test_sample = (
         Path(__file__).parent
         / "resources"
@@ -57,13 +70,54 @@ def test_containers(minio):
     )
 
     remote_path = (
-        f"s3://{bucket}/"
+        f"s3://{bucket}/{prefix}/"
         f"submission_date_s3={submission_date}/"
         f"namespace={namespace}/"
         f"doc_id={doc_id}/"
         f"doc_version={doc_version}/"
-        "long-meaningless-hash.json"
+        "long-hash.json"
     )
 
     awscli(f"s3 cp {test_sample} {remote_path}")
-    assert False
+    assert "long-hash.json" in awscli(f"s3 ls --recursive s3://{bucket}")
+    print(awscli(f"s3 cp {remote_path} -"))
+
+
+    sync = cwd.parent / "sync.sh"
+    assert sync.exists()
+
+    # setup the test directory
+    test_dir = tmp_path / "root"
+
+    # move testing schemas into mozilla-pipeline-schemas
+    shutil.copytree(
+        str(cwd / "resources" / "schemas"),
+        str(test_dir / "mozilla-pipeline-schemas" / "schemas"),
+    )
+
+    # run the synchronization script
+    res = subprocess.run(
+        [sync],
+        env={
+            "AWS_ACCESS_KEY_ID": TEST_ACCESS_KEY,
+            "AWS_SECRET_ACCESS_KEY": TEST_SECRET_KEY,
+            "SOURCE_DATA_BUCKET": bucket,
+            "SOURCE_DATA_PREFIX": prefix,
+            "ENDPOINT_URL": "http://localhost:9000",
+            "INCLUDE_TESTS": "false",
+            "DEBUG": "true",
+        },
+        cwd=test_dir,
+    )
+    assert res.returncode == 0
+
+    # assert that files are being copied down correctly
+    resource = test_dir / "resources"
+    assert (resource / "schemas" / namespace / doc_id / "test.1.schema.json").exists()
+    assert (
+        resource
+        / "data"
+        / submission_date
+        / namespace
+        / f"{doc_id}.{doc_version}.batch.json"
+    ).exists()

--- a/tests/test_command_sync.py
+++ b/tests/test_command_sync.py
@@ -1,0 +1,69 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import pytest
+import docker
+import subprocess
+from pathlib import Path
+
+TEST_ACCESS_KEY = "testing-id"
+TEST_SECRET_KEY = "testing-key"
+
+
+@pytest.fixture
+def minio():
+    client = docker.from_env()
+    container = client.containers.run(
+        "minio/minio:latest",
+        "server data/",
+        detach=True,
+        environment={
+            "MINIO_ACCESS_KEY": TEST_ACCESS_KEY,
+            "MINIO_SECRET_KEY": TEST_SECRET_KEY,
+        },
+        ports={"9000/tcp": "9000"},
+    )
+    yield container
+    container.stop()
+
+
+def awscli(command):
+    res = subprocess.run(
+        ["aws", "--endpoint-url", "http://localhost:9000"] + command.split(),
+        stdout=subprocess.PIPE,
+        env={
+            "AWS_ACCESS_KEY_ID": TEST_ACCESS_KEY,
+            "AWS_SECRET_ACCESS_KEY": TEST_SECRET_KEY,
+        },
+    )
+    return res.stdout
+
+
+def test_containers(minio):
+    bucket = "test-bucket"
+    submission_date = "20181212"
+    namespace = "testing"
+    doc_id = "test"
+    doc_version = "1"
+
+    awscli(f"s3 mb s3://{bucket}")
+    test_sample = (
+        Path(__file__).parent
+        / "resources"
+        / "data"
+        / namespace
+        / doc_id
+        / "test.1.batch.json"
+    )
+
+    remote_path = (
+        f"s3://{bucket}/"
+        f"submission_date_s3={submission_date}/"
+        f"namespace={namespace}/"
+        f"doc_id={doc_id}/"
+        f"doc_version={doc_version}/"
+        "long-meaningless-hash.json"
+    )
+
+    awscli(f"s3 cp {test_sample} {remote_path}")
+    assert False


### PR DESCRIPTION
This fixes #34 by cutting the paths from `aws s3 ls --recursive` to keep the last 5 components corresponding to the known dataset partitions. 

This also adds tests using [minio](https://github.com/minio/minio) which is loaded as a fixture at test time. The parametrized test identified the bug which is fixed in this PR.

