### PR TITLE
Skip `command_sync` tests on CI and other etc. changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ $ make test
 
 You may also run the tests in docker in the same way as CI.
 A `junit.xml` file is generated in a `test-reports` folder.
+The image must be rebuilt to include modified test files.
 
 ```bash
 IMAGE=edge-validator:latest ./docker_env.sh test

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ You may also run the tests in docker in the same way as CI.
 A `junit.xml` file is generated in a `test-reports` folder.
 
 ```bash
-IMAGE=edge-validator:latest ./test_env.sh test
+IMAGE=edge-validator:latest ./docker_env.sh test
 ```
 
 # Running Integration Tests

--- a/docker_env.sh
+++ b/docker_env.sh
@@ -4,7 +4,8 @@ IMAGE=${IMAGE:-"edge-validator:latest"}
 
 report_path=$(pwd)/"test-reports"
 
-container_id="$(docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -tid $IMAGE)"
+# disable tests on CI by checking for this environment variable.
+container_id="$(docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e CI=true -tid $IMAGE)"
 cleanup() {
     docker stop "${container_id}"
 }

--- a/integration.py
+++ b/integration.py
@@ -267,8 +267,8 @@ def sync_cmd(**kwargs):
     """
     # Backwards compatibility layer for `sync.sh`
     options = {
-        'SRC_DATA_BUCKET': kwargs['data_bucket'],
-        'SRC_DATA_PREFIX': kwargs['data_prefix'],
+        'SOURCE_DATA_BUCKET': kwargs['data_bucket'],
+        'SOURCE_DATA_PREFIX': kwargs['data_prefix'],
         'MPS_ROOT': kwargs['schema_root'],
         'OUTPUT_PATH': kwargs['output_path'],
         'INCLUDE_DATA': "true" if kwargs['include_data'] else "false",


### PR DESCRIPTION
This PR includes 3 separate changes

* Fixes issue #33 
* Returns the proper error code when running tests inside of docker via `docker_env.sh`
* Ignores the `command_sync` tests on CI since they include a dependency that is difficult to set-up in CI.